### PR TITLE
Back navigation for food info page fixed!!!

### DIFF
--- a/app/src/main/java/com/example/cafmealplanner/ui/Menu/FoodInfo.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Menu/FoodInfo.java
@@ -19,6 +19,7 @@ import android.widget.ImageButton;
 import android.widget.TextView;
 
 import com.example.cafmealplanner.R;
+import com.example.cafmealplanner.ui.Schedule.MealInfo;
 
 import java.util.Vector;
 
@@ -102,12 +103,22 @@ public class FoodInfo extends Fragment implements View.OnClickListener {
             setRating(5);
         }
         else if (v == getView().findViewById(R.id.back)) {
-            // Get the fragment manager
+            // Get the fragment manager and transaction
             FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
+            FragmentTransaction transaction = fragmentManager.beginTransaction();
+            transaction.setReorderingAllowed(true);
 
-            // Remove the current fragment
-            if (fragmentManager.getBackStackEntryCount() > 0)
-                fragmentManager.popBackStack();
+            // Replace the current fragment with whatever came before
+            if (fragmentManager.getBackStackEntryCount() > 0) {
+                int count = fragmentManager.getBackStackEntryCount();
+
+                if (fragmentManager.getBackStackEntryAt(count - 1).getName() == "MENU")
+                    transaction.replace(R.id.nav_host_fragment_activity_main, MenuFragment.class, null);
+                else if (fragmentManager.getBackStackEntryAt(count - 1).getName() == "MEAL_INFO")
+                    transaction.replace(R.id.nav_host_fragment_activity_main, MealInfo.class, null);
+
+                transaction.commit();
+            }
         }
     }
 

--- a/app/src/main/java/com/example/cafmealplanner/ui/Menu/FoodInfo.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Menu/FoodInfo.java
@@ -1,10 +1,8 @@
 package com.example.cafmealplanner.ui.Menu;
 
-import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
-
-import android.graphics.drawable.Drawable;
 
 import android.os.Bundle;
 
@@ -17,9 +15,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.EditText;
 import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.example.cafmealplanner.R;
@@ -60,8 +56,6 @@ public class FoodInfo extends Fragment implements View.OnClickListener {
             }
         }
 
-
-
         // Implement the rating and back navigation buttons
         getView().findViewById(R.id.rating).setOnClickListener((View.OnClickListener) this);
         getView().findViewById(R.id.star1).setOnClickListener(this);
@@ -70,7 +64,7 @@ public class FoodInfo extends Fragment implements View.OnClickListener {
         getView().findViewById(R.id.star4).setOnClickListener(this);
         getView().findViewById(R.id.star5).setOnClickListener(this);
 
-        getView().findViewById(R.id.backToMenu).setOnClickListener(this);
+        getView().findViewById(R.id.back).setOnClickListener(this);
 
         //allow info text to scroll
         ingredientsList.setMovementMethod(new ScrollingMovementMethod());
@@ -107,17 +101,13 @@ public class FoodInfo extends Fragment implements View.OnClickListener {
         else if (v == getView().findViewById(R.id.star5) && editRatingOn) {
             setRating(5);
         }
-        else if (v == getView().findViewById(R.id.backToMenu)) {
-            // Create new fragment and transaction
+        else if (v == getView().findViewById(R.id.back)) {
+            // Get the fragment manager
             FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
-            FragmentTransaction transaction = fragmentManager.beginTransaction();
-            transaction.setReorderingAllowed(true);
 
-            // Replace whatever is in the fragment_container view with this fragment
-            transaction.replace(R.id.nav_host_fragment_activity_main, MenuFragment.class, null);
-            // Commit the transaction
-
-            transaction.commit();
+            // Remove the current fragment
+            if (fragmentManager.getBackStackEntryCount() > 0)
+                fragmentManager.popBackStack();
         }
     }
 

--- a/app/src/main/java/com/example/cafmealplanner/ui/Menu/MenuFragment.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Menu/MenuFragment.java
@@ -272,7 +272,7 @@ public class MenuFragment extends Fragment implements View.OnClickListener {
         transaction.replace(R.id.nav_host_fragment_activity_main, FoodInfo.class, null);
 
         // Add this transaction to the stack to support back navigation
-        transaction.addToBackStack(null);
+        transaction.addToBackStack("MENU");
 
         // Commit the transaction
         transaction.commit();

--- a/app/src/main/java/com/example/cafmealplanner/ui/Menu/MenuFragment.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Menu/MenuFragment.java
@@ -267,8 +267,13 @@ public class MenuFragment extends Fragment implements View.OnClickListener {
         FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.setReorderingAllowed(true);
+
         // Replace whatever is in the fragment_container view with this fragment
         transaction.replace(R.id.nav_host_fragment_activity_main, FoodInfo.class, null);
+
+        // Add this transaction to the stack to support back navigation
+        transaction.addToBackStack(null);
+
         // Commit the transaction
         transaction.commit();
     }

--- a/app/src/main/java/com/example/cafmealplanner/ui/Schedule/MealInfo.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Schedule/MealInfo.java
@@ -83,10 +83,14 @@ public class MealInfo extends Fragment implements View.OnClickListener {
             FragmentManager fragmentManager = getActivity().getSupportFragmentManager();
             FragmentTransaction transaction = fragmentManager.beginTransaction();
             transaction.setReorderingAllowed(true);
+
             // Replace whatever is in the fragment_container view with this fragment
             transaction.replace(R.id.nav_host_fragment_activity_main, ScheduleFragment.class, null);
-            // Commit the transaction
 
+            // Add the transaction to the back stack to support back navigation
+            transaction.addToBackStack(null);
+
+            // Commit the transaction
             transaction.commit();
         }
     }

--- a/app/src/main/java/com/example/cafmealplanner/ui/Schedule/MealInfo.java
+++ b/app/src/main/java/com/example/cafmealplanner/ui/Schedule/MealInfo.java
@@ -88,7 +88,7 @@ public class MealInfo extends Fragment implements View.OnClickListener {
             transaction.replace(R.id.nav_host_fragment_activity_main, ScheduleFragment.class, null);
 
             // Add the transaction to the back stack to support back navigation
-            transaction.addToBackStack(null);
+            transaction.addToBackStack("MEAL_INFO");
 
             // Commit the transaction
             transaction.commit();

--- a/app/src/main/res/layout/fragment_food_info.xml
+++ b/app/src/main/res/layout/fragment_food_info.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:text="@string/location"
         android:textSize="24sp"
-        app:layout_constraintTop_toBottomOf="@id/backToMenu"
+        app:layout_constraintTop_toBottomOf="@id/back"
         android:layout_marginTop="50dp"
         app:layout_constraintLeft_toLeftOf="parent"
         android:layout_marginLeft="20dp"
@@ -32,7 +32,7 @@
          />
 
     <ImageButton
-        android:id="@+id/backToMenu"
+        android:id="@+id/back"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:rotationY="180"
@@ -47,8 +47,8 @@
         android:id="@+id/mealName"
         android:layout_width="300dp"
         android:layout_height="wrap_content"
-        app:layout_constraintLeft_toRightOf="@id/backToMenu"
-        app:layout_constraintTop_toTopOf="@id/backToMenu"
+        app:layout_constraintLeft_toRightOf="@id/back"
+        app:layout_constraintTop_toTopOf="@id/back"
         android:layout_marginLeft="20dp"
         android:text="@string/dinner_option"
         android:textSize="30sp"


### PR DESCRIPTION
Basically now when you press the back button on the food info page it takes you back to wherever you were before. Just for the record, calling popBackStack() or popBackStackImmediate() doesn't work which is why it's implemented this way, by replacing the fragment based on the name that was last added to the "back stack" (done when you navigate to the food info page).

I also simplified some stuff with the star ratings; I did it before I saw your updates Ellieanna, so even though I updated my branch later to be in sync with yours, I hope I haven't accidentally written over anything you did.